### PR TITLE
install_dependencies_pkg.sh: add two lines, "urg_node and amcl"

### DIFF
--- a/dependency/install_dependencies_pkg.sh
+++ b/dependency/install_dependencies_pkg.sh
@@ -35,3 +35,5 @@ libqwt-dev \
 ros-indigo-kobuki-msgs \
 ros-indigo-kobuki* \
 freeglut3-dev \
+ros-indigo-amcl \
+ros-indigo-urg-node


### PR DESCRIPTION
I added two lines to install_dependencies_pkg.sh.
<p>
<ul>
<li>ros-indigo-urg-node</li>
<li>ros-indigo-amcl</li>
</ul>
</p>